### PR TITLE
Add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Build with Maven
+      run: mvn clean install
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+    - name: Set up Docker
+      uses: docker/setup-buildx-action@v1
+
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Run Docker Compose
+      run: docker-compose up --build -d
+
+    - name: Verify application
+      run: |
+        sleep 30
+        curl --fail http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ The docker network created by `docker-compose` maps pretty well to a multi-tier 
 * [XSS - Cross Site Scripting](exercises/02-xss.md)
 * [SSRF - Server Side Request Forgery](exercises/03-ssrf.md)
 * [RCE - Remote Code Execution & Reverse Shell](exercises/04-rce-reverse-shell.md)
+
+## Continuous Integration
+
+This repository uses GitHub Actions for Continuous Integration (CI). The CI workflow is defined in the `.github/workflows/ci.yml` file.
+
+The CI workflow is triggered on push and pull request events to the `main` branch. It consists of the following jobs:
+
+* `build`: Sets up Java 8, checks out the repository, and runs `mvn clean install` to build the application.
+* `test`: Runs after the `build` job, sets up Docker, and runs `docker-compose up` to start the services and verify the application.
+
+You can view the CI results in the "Actions" tab of the GitHub repository.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for Wynxx Bot for the 9ebb7f4191b06163ab045e65380bb20d13da181a

**Description:** This pull request introduces a new GitHub Actions workflow for Continuous Integration (CI) to the repository. The workflow automates the build and test processes, ensuring that code changes are validated automatically. The CI pipeline is configured to run on manual trigger (workflow_dispatch) and consists of two sequential jobs: one for building the Java application using Maven, and another for testing the application using Docker Compose. Additionally, the README.md file has been updated to document this new CI functionality.

**Summary:**
- **.github/workflows/ci.yml** (added) - New CI workflow file that defines the automated pipeline with the following components:
  - Workflow trigger: `workflow_dispatch` (manual trigger only)
  - **Build job**: Runs on Ubuntu latest, sets up JDK 1.8, checks out the code, and executes `mvn clean install`
  - **Test job**: Depends on build job completion, sets up Docker Buildx, checks out the repository, runs Docker Compose in detached mode, waits 30 seconds, then verifies the application is running by calling `http://localhost:8080`

- **README.md** (modified) - Added documentation section explaining the CI workflow, including trigger events, job descriptions, and instructions on how to view CI results in the Actions tab

**Recommendation:**
1. **Trigger Configuration**: The workflow only uses `workflow_dispatch`, meaning it must be triggered manually. Consider adding `push` and `pull_request` triggers to automate CI on code changes, especially since the README states it's "triggered on push and pull request events" (documentation mismatch).
2. **Java Version**: JDK 1.8 is quite outdated. Consider upgrading to a more recent LTS version (Java 11 or 17) unless there's a specific requirement.
3. **Action Versions**: The actions used (`actions/setup-java@v1`, `actions/checkout@v2`) are outdated. Update to latest versions (`actions/setup-java@v4`, `actions/checkout@v4`) for security patches and new features.
4. **Hardcoded Sleep**: The `sleep 30` is fragile. Consider using a health check loop or a tool like `wait-for-it` for more reliable service readiness checks.
5. **Missing Cleanup**: Add a cleanup step to run `docker-compose down` after tests to ensure proper resource cleanup.

**Explanation of vulnerabilities:**

1. **Outdated GitHub Actions**: Using outdated action versions (`v1`, `v2`) may expose the pipeline to known vulnerabilities that have been patched in newer versions.
   
   ```yaml
   # Vulnerable (outdated versions)
   - uses: actions/setup-java@v1
   - uses: actions/checkout@v2
   
   # Corrected (use latest versions)
   - uses: actions/setup-java@v4
     with:
       java-version: '8'
       distribution: 'temurin'
   - uses: actions/checkout@v4
   ```

2. **Insecure curl command**: The `curl --fail http://localhost:8080` uses HTTP without verifying SSL. While this is localhost, it's a good practice to document why HTTPS is not used. No immediate fix needed for localhost testing, but ensure production endpoints use HTTPS.

3. **No timeout on Docker Compose**: The `docker-compose up` command could hang indefinitely if containers fail to start properly. Add a timeout mechanism:
   
   ```yaml
   - name: Run Docker Compose
     run: |
       docker-compose up --build -d
       timeout 60 bash -c 'until docker-compose ps | grep -q "Up"; do sleep 2; done'
   ```