### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/Cowsay.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,13 +1,16 @@
 package com.scalesec.vulnado;
+import java.util.logging.Logger;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 
+  private Cowsay() { throw new IllegalStateException("Utility class"); }
+  private static final Logger logger = Logger.getLogger(Cowsay.class.getName());
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
+    String cmd = "/usr/games/cowsay '" + input.replace("'", "'\\''") + "'";
+    logger.info(cmd);
     processBuilder.command("bash", "-c", cmd);
 
     StringBuilder output = new StringBuilder();


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 219584149c776a8a9e1e2e7eace41e1f407dd934

**Description:** This pull request updates the `Cowsay.java` file to improve logging, enhance security, and enforce better coding practices. The changes include adding a logger, escaping single quotes in the input to prevent command injection, and making the class non-instantiable by adding a private constructor.

**Summary:**
- **File Modified:** `src/main/java/com/scalesec/vulnado/Cowsay.java`
  - **Added:** 
    - `import java.util.logging.Logger;` to enable logging.
    - `private static final Logger logger = Logger.getLogger(Cowsay.class.getName());` to initialize the logger.
    - `private Cowsay() { throw new IllegalStateException("Utility class"); }` to prevent instantiation of the utility class.
  - **Modified:**
    - Changed `System.out.println(cmd);` to `logger.info(cmd);` for better logging practices.
    - Escaped single quotes in the input string with `input.replace("'", "'\\''")` to prevent command injection vulnerabilities.

**Recommendation:** 
- Ensure that the logger configuration is set up properly in the application to capture the logs.
- Consider adding unit tests to verify that the input sanitization works as expected and that the logger outputs the correct information.
- Review other parts of the codebase for similar vulnerabilities and apply similar fixes if necessary.

**Explanation of vulnerabilities:**
- **Command Injection Vulnerability:** The original code concatenated user input directly into a shell command, which could be exploited by an attacker to execute arbitrary commands. This was mitigated by escaping single quotes in the input string.
  ```java
  String cmd = "/usr/games/cowsay '" + input.replace("'", "'\\''") + "'";
  ```
- **Improper Logging:** Using `System.out.println` for logging is not recommended for production code. This was replaced with a proper logging mechanism using `Logger`.
  ```java
  logger.info(cmd);
  ```
- **Utility Class Instantiation:** The class was made non-instantiable by adding a private constructor, which is a good practice for utility classes.
  ```java
  private Cowsay() { throw new IllegalStateException("Utility class"); }
  ```