### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -1,4 +1,6 @@
 package com.scalesec.vulnado;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -11,8 +13,10 @@ import java.net.*;
 
 
 public class LinkLister {
+  private LinkLister() { throw new IllegalStateException("Utility class"); }
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +29,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.log(Level.INFO, host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the fca066da15c4542818882892e67d7cf99a574e71

**Description:** This pull request updates the `LinkLister.java` file to improve code quality and logging practices. The changes include the addition of a logger, a private constructor to prevent instantiation, and minor code cleanups.

**Summary:**
- **File:** `src/main/java/com/scalesec/vulnado/LinkLister.java` (modified)
  - **Added:** 
    - `import java.util.logging.Level;`
    - `import java.util.logging.Logger;`
    - `private LinkLister() { throw new IllegalStateException("Utility class"); }`
    - `private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());`
  - **Modified:**
    - Changed `new ArrayList<String>()` to `new ArrayList<>()` for type inference.
    - Replaced `System.out.println(host);` with `LOGGER.log(Level.INFO, host);` for better logging practices.

**Recommendation:** 
- Ensure that the logging level used (`Level.INFO`) is appropriate for the information being logged. If the host information is sensitive, consider using a different logging level or obfuscating the data.
- Review the exception handling to ensure that all potential exceptions are properly managed and logged.
- Consider adding unit tests to verify the behavior of the `getLinks` and `getLinksV2` methods, especially with different types of URLs.

**Explanation of vulnerabilities:**
- **Logging Sensitive Information:** Logging the host information might expose sensitive data. Ensure that the logging level is appropriate and consider obfuscating sensitive information.
  ```java
  // Example of obfuscating sensitive information
  String obfuscatedHost = host.replaceAll("(?<=.{3}).", "*");
  LOGGER.log(Level.INFO, obfuscatedHost);
  ```
- **Utility Class Instantiation Prevention:** The addition of a private constructor to prevent instantiation of the utility class is a good practice to ensure that the class is not instantiated.
  ```java
  private LinkLister() { 
    throw new IllegalStateException("Utility class"); 
  }
  ```

Overall, the changes improve the code quality and logging practices, but attention should be given to the handling of sensitive information in logs.