### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -9,10 +9,13 @@ import java.util.List;
 import java.io.IOException;
 import java.net.*;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +28,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.log(Level.INFO, host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the d91f1c16b509a5e9d535c205cf6e304f36064480

**Description:** Atualização no arquivo `LinkLister.java` para melhorar a legibilidade do código e substituir a saída de console por um logger.

**Summary:** 
- **src/main/java/com/scalesec/vulnado/LinkLister.java** (modificado)
  - Adição das importações `java.util.logging.Level` e `java.util.logging.Logger`.
  - Declaração de um logger estático `LOGGER` para a classe `LinkLister`.
  - Substituição de `new ArrayList<String>()` por `new ArrayList<>()` para simplificação.
  - Substituição de `System.out.println(host)` por `LOGGER.log(Level.INFO, host)` para utilizar o logger.

**Recommendation:** 
- **Uso de Logger:** A substituição de `System.out.println` por `LOGGER.log` é uma boa prática, pois permite um melhor controle sobre a saída de logs e facilita a manutenção e depuração do código.
- **Simplificação de Generics:** A simplificação de `new ArrayList<String>()` para `new ArrayList<>()` é recomendada e segue as boas práticas de codificação em Java.
- **Nível de Log:** Verifique se o nível de log `Level.INFO` é o mais adequado para a mensagem. Dependendo do contexto, `Level.DEBUG` ou outro nível pode ser mais apropriado.

**Explanation of vulnerabilities:** 
- **Uso de IPs Privados:** A verificação de IPs privados (`172.`, `192.168`, `10.`) é uma boa prática para evitar acessos não autorizados a redes internas. No entanto, a lógica pode ser aprimorada para cobrir todos os intervalos de IPs privados de forma mais robusta.
  ```java
  if (host.matches("^(172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.|10\\.).*")) {
      throw new BadRequest("Use of Private IP");
  }
  ```
  Essa expressão regular cobre todos os intervalos de IPs privados de forma mais precisa.