### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -14,28 +14,28 @@ public class CommentsController {
   private String secret;
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the a3bdff9608fefc9d60778aeb27c0015981f8b39f

**Description:** Atualização no arquivo `CommentsController.java` para utilizar anotações mais específicas do Spring Framework e melhorar a encapsulação da classe `CommentRequest`.

**Summary:**
- **Arquivo Modificado:** `src/main/java/com/scalesec/vulnado/CommentsController.java`
  - Substituição das anotações genéricas `@RequestMapping` por anotações específicas `@GetMapping`, `@PostMapping` e `@DeleteMapping` para melhorar a legibilidade e a manutenção do código.
  - Alteração dos modificadores de acesso dos atributos da classe `CommentRequest` de `public` para `private` para melhorar a encapsulação e a segurança dos dados.

**Recommendation:** 
- **Uso de Anotações Específicas:** A substituição das anotações genéricas por anotações específicas é uma boa prática, pois torna o código mais legível e fácil de manter. Continue utilizando anotações específicas sempre que possível.
- **Encapsulamento:** A mudança dos atributos da classe `CommentRequest` para `private` é uma melhoria significativa em termos de encapsulamento. Considere adicionar métodos `getter` e `setter` para acessar esses atributos de forma controlada.
- **Validação de Dados:** Adicione validações nos métodos que manipulam os dados de entrada, como `createComment` e `deleteComment`, para garantir que os dados recebidos sejam válidos e seguros.

**Explanation of vulnerabilities:**
- **Cross-Origin Resource Sharing (CORS):** A anotação `@CrossOrigin(origins = "*")` permite que qualquer origem acesse os endpoints, o que pode ser um risco de segurança. Considere restringir as origens permitidas para aumentar a segurança.
  ```java
  @CrossOrigin(origins = "https://trusteddomain.com")
  ```
- **Autenticação e Autorização:** A autenticação é feita através do método `User.assertAuth(secret, token)`, mas não há verificação de autorização para garantir que o usuário tem permissão para criar ou deletar comentários. Considere adicionar verificações de autorização.
  ```java
  if (!User.hasPermission(token, "CREATE_COMMENT")) {
      throw new UnauthorizedException("User does not have permission to create comments");
  }
  ```

Essas melhorias ajudarão a aumentar a segurança e a robustez do código.