### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -1,4 +1,6 @@
 package com.scalesec.vulnado;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -11,8 +13,9 @@ import java.net.*;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +28,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.log(Level.INFO, host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {
@@ -35,4 +38,6 @@ public class LinkLister {
       throw new BadRequest(e.getMessage());
     }
   }
+  private LinkLister() {
 }
+    throw new UnsupportedOperationException("Utility class");


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 03e7069dafcae84cc6299579be72d7e547c59546

**Description:** Atualização no arquivo `LinkLister.java` para melhorar a qualidade do código e a segurança. Foram adicionados logs para substituir `System.out.println` e foi implementado um construtor privado para evitar a instanciação da classe utilitária.

**Summary:** 
- **src/main/java/com/scalesec/vulnado/LinkLister.java** (modificado)
  - Adição das importações `java.util.logging.Level` e `java.util.logging.Logger`.
  - Substituição de `System.out.println` por `LOGGER.log(Level.INFO, ...)` para melhorar o gerenciamento de logs.
  - Remoção do tipo genérico explícito na inicialização de `ArrayList<String>` para `ArrayList<>`.
  - Implementação de um construtor privado para a classe `LinkLister` para evitar a instanciação da classe utilitária.
  - Adição de uma exceção `UnsupportedOperationException` no construtor privado para garantir que a classe não seja instanciada.

**Recommendation:** 
- Verificar se o nível de log `Level.INFO` é adequado para a informação que está sendo registrada. Dependendo do contexto, pode ser necessário ajustar para outro nível, como `Level.WARNING` ou `Level.SEVERE`.
- Considerar a adição de testes unitários para garantir que a classe `LinkLister` não possa ser instanciada e que os logs estão sendo gerados corretamente.
- Avaliar a necessidade de adicionar mais informações no log, como o URL completo, para facilitar a rastreabilidade.

**Explanation of vulnerabilities:** 
- **Uso de `System.out.println`:** Substituir `System.out.println` por um logger é uma boa prática de segurança e qualidade, pois permite um melhor controle sobre a saída de logs e facilita a desativação ou redirecionamento de logs em diferentes ambientes.
  ```java
  // Correção realizada
  LOGGER.log(Level.INFO, host);
  ```
- **Instanciação de classe utilitária:** A implementação de um construtor privado com uma exceção garante que a classe `LinkLister` não possa ser instanciada, o que é uma boa prática para classes utilitárias.
  ```java
  // Correção realizada
  private LinkLister() {
    throw new UnsupportedOperationException("Utility class");
  }
  ```