### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -10,12 +10,19 @@ import java.io.IOException;
 import java.net.*;
 
 
+import java.util.logging.Logger;
 public class LinkLister {
+    private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+
+    List<String> result = new ArrayList<>();
+    private LinkLister() {
     Document doc = Jsoup.connect(url).get();
+        // Private constructor to hide the implicit public one
     Elements links = doc.select("a");
+    }
     for (Element link : links) {
+
       result.add(link.absUrl("href"));
     }
     return result;
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para GFT AI Impact Bot para o ac8f10fc2b4695e64fbcc93a89c32da526377fdc

**Descrição:** Foram realizadas várias alterações na classe LinkLister para melhorar a segurança, o desempenho e seguir as melhores práticas de programação Java.

**Resumo:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)
  - Adicionado import para java.util.logging.Logger
  - Criado um logger estático final para a classe
  - Modificado o tipo de lista retornada para ArrayList<>() (diamond operator)
  - Adicionado construtor privado para evitar instanciação
  - Substituído System.out.println por logger.info para logging
  - Pequenas melhorias de formatação e espaçamento

**Recomendação:** 
1. Considerar o uso de uma biblioteca de logging mais robusta, como SLF4J ou Log4j2, em vez do java.util.logging.
2. Avaliar a possibilidade de tornar a classe LinkLister final, já que possui apenas métodos estáticos.
3. Considerar a adição de validação de entrada para o parâmetro 'url' nos métodos getLinks e getLinksV2.
4. Avaliar a necessidade de tratamento de exceções mais específicas no método getLinksV2.

**Explicação de vulnerabilidades:** 
1. A alteração do System.out.println para logger.info resolve uma vulnerabilidade de logging, pois evita a exposição de informações sensíveis no console. No entanto, é importante garantir que o logger esteja configurado corretamente para não logar informações sensíveis em ambientes de produção.

2. A adição do construtor privado evita a instanciação não intencional da classe, o que é uma boa prática de segurança para classes utilitárias.

3. Não foram encontradas outras vulnerabilidades significativas nas alterações realizadas. No entanto, é importante notar que o método getLinksV2 ainda pode ser vulnerável a ataques de injeção se a entrada do usuário não for devidamente sanitizada antes de ser usada para criar um objeto URL.

Sugestão de melhoria para o método getLinksV2:

```java
public static List<String> getLinksV2(String url) throws BadRequest {
    if (url == null || url.trim().isEmpty()) {
        throw new BadRequest("URL cannot be null or empty");
    }
    
    try {
        URL aUrl = new URL(url);
        String host = aUrl.getHost();
        logger.info("Processing host: " + host);
        
        if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")) {
            throw new BadRequest("Use of Private IP is not allowed");
        } else {
            return getLinks(url);
        }
    } catch (MalformedURLException e) {
        throw new BadRequest("Invalid URL format: " + e.getMessage());
    } catch (IOException e) {
        logger.severe("Error while fetching links: " + e.getMessage());
        throw new BadRequest("Error while fetching links");
    }
}
```

Esta sugestão inclui validação de entrada, tratamento mais específico de exceções e mensagens de erro mais informativas.