### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -10,12 +10,19 @@ import java.io.IOException;
 import java.net.*;
 
 
+import java.util.logging.Logger;
 public class LinkLister {
+    private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+
+    List<String> result = new ArrayList<>();
+    private LinkLister() {
     Document doc = Jsoup.connect(url).get();
+        // Private constructor to hide the implicit public one
     Elements links = doc.select("a");
+    }
     for (Element link : links) {
+
       result.add(link.absUrl("href"));
     }
     return result;
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado para GFT AI Impact Bot para o a3d6702657caaa4d80c986369c50f7bc612992dd

**Descrição:** Foram realizadas alterações na classe LinkLister para melhorar a segurança, legibilidade e boas práticas de programação. As principais mudanças incluem a adição de um logger, a criação de um construtor privado e a substituição de System.out.println por um log adequado.

**Resumo:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)
  - Adicionado import para java.util.logging.Logger
  - Criado um logger estático final para a classe
  - Adicionado um construtor privado para evitar instanciação
  - Alterado ArrayList para usar diamond operator (<>)
  - Substituído System.out.println por LOGGER.info()

**Recomendação:** 
1. Considerar o uso de um framework de logging mais robusto, como SLF4J ou Log4j2, para maior flexibilidade e controle.
2. Avaliar a possibilidade de tornar a classe LinkLister final, já que possui apenas métodos estáticos.
3. Considerar a adição de validações adicionais para a URL de entrada, como verificar se é nula ou vazia.
4. Avaliar a necessidade de tratar exceções específicas do Jsoup.connect() separadamente.

**Explicação de vulnerabilidades:** 
1. A alteração do System.out.println para LOGGER.info() melhora a segurança ao evitar a exposição de informações sensíveis no console. No entanto, ainda é necessário garantir que as informações de log sejam adequadamente protegidas.

2. A adição do construtor privado previne a instanciação não intencional da classe, o que é uma boa prática para classes utilitárias com apenas métodos estáticos.

3. A validação de IPs privados na função getLinksV2 é uma boa medida de segurança, mas pode ser aprimorada. Sugestão de melhoria:

```java
private static final Pattern PRIVATE_IP_PATTERN = Pattern.compile("^(10\\.|172\\.(1[6-9]|2[0-9]|3[0-1])\\.|192\\.168\\.)");

if (PRIVATE_IP_PATTERN.matcher(host).find()) {
    throw new BadRequest("Uso de IP Privado não permitido");
}
```

Esta implementação usa uma expressão regular mais precisa para identificar IPs privados e é mais eficiente do que múltiplas verificações com startsWith.