### PR TITLE
Update LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -18,10 +18,7 @@ public class LinkLister {
     for (Element link : links) {
       result.add(link.absUrl("href"));
     }
-    return result;
-  }
-
-  public static List<String> getLinksV2(String url) throws BadRequest {
+    g> getLinksV2(String url) throws BadRequest {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 7220abfbb7e48a0abdbac59a4e00b42421bdea1f

**Description:** This pull request modifies the `LinkLister.java` file, specifically altering the `getLinks` method and removing the `getLinksV2` method. The changes appear to be an attempt to merge functionality from both methods, but the implementation is incomplete and introduces syntax errors.

**Summary:** 
- src/main/java/com/scalesec/vulnado/LinkLister.java (modified)
  - Removed the return statement and closing brace of the `getLinks` method
  - Partially removed the `getLinksV2` method, leaving only its signature and first few lines
  - Introduced a syntax error by merging parts of both methods incorrectly

**Recommendation:** This pull request should not be merged in its current state. The changes introduce severe syntax errors and break the functionality of the `LinkLister` class. The developer should:

1. Decide whether to keep `getLinks`, `getLinksV2`, or merge their functionalities.
2. If merging, ensure that the combined method is syntactically correct and logically sound.
3. Maintain proper method structure, including return statements and closing braces.
4. Consider renaming the method if it now combines functionality from both original methods.
5. Update any calls to these methods throughout the codebase to reflect the changes.
6. Add appropriate comments to explain the new method's functionality.
7. Ensure that error handling is properly implemented, especially if keeping the `BadRequest` exception from `getLinksV2`.

**Explanation of vulnerabilities:** While the original code didn't appear to have obvious security vulnerabilities, the incomplete merging of methods could potentially introduce new issues:

1. Error Handling: The partial removal of `getLinksV2` leaves the `BadRequest` exception handling incomplete. This could lead to unhandled exceptions or unexpected behavior.

2. URL Validation: The `getLinksV2` method seemed to include some URL validation (checking the host), which is now partially removed. This could potentially allow malformed or malicious URLs to be processed without proper checks.

To address these concerns, consider implementing proper URL validation and error handling:

```java
public static List<String> getLinks(String url) throws IOException, BadRequest {
    try {
        URL aUrl = new URL(url);
        String host = aUrl.getHost();
        // Add additional URL validation here if needed

        Document doc = Jsoup.connect(url).get();
        Elements links = doc.select("a[href]");
        List<String> result = new ArrayList<>();
        for (Element link : links) {
            result.add(link.absUrl("href"));
        }
        return result;
    } catch (MalformedURLException e) {
        throw new BadRequest("Invalid URL provided");
    }
}
```

This implementation combines URL validation from `getLinksV2` with the link extraction logic from `getLinks`, while also providing proper error handling.