### PR TITLE
Update User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -46,7 +46,7 @@ public class User {
 
       String query = "select * from users where username = '" + un + "' limit 1";
       System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery(query);we
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");

--- a/wiki/src/main/java/com/scalesec/vulnado/User.java.md
+++ b/wiki/src/main/java/com/scalesec/vulnado/User.java.md
@@ -1,0 +1,69 @@
+# User.java: User Authentication and Database Interaction
+
+## Overview
+
+This Java class, `User`, handles user authentication, token generation, and database interactions for user retrieval. It includes methods for creating JWT tokens, validating authentication, and fetching user data from a PostgreSQL database.
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A["User Constructor"] --> B["Token Generation"]
+    B --> C{"Assert Authentication"}
+    C -->|"Valid"| D["Fetch User"]
+    C -->|"Invalid"| E["Throw Unauthorized"]
+    D --> F["Database Query"]
+    F -->|"User Found"| G["Create User Object"]
+    F -->|"User Not Found"| H["Return null"]
+```
+
+## Insights
+
+- The class uses JWT (JSON Web Tokens) for authentication.
+- User data is stored in a PostgreSQL database.
+- The `fetch` method uses a potentially unsafe SQL query construction.
+- Error handling is implemented, but exceptions are printed to standard error.
+- The class doesn't handle password hashing or verification directly.
+
+## Dependencies
+
+```mermaid
+flowchart LR
+    User.java --- |"Uses"| jwt["JWT Library"]
+    User.java --- |"Connects"| postgres["PostgreSQL Database"]
+    User.java --- |"Imports"| java_sql["java.sql"]
+```
+
+- `JWT Library`: Used for token generation and validation (io.jsonwebtoken package)
+- `PostgreSQL Database`: Stores and retrieves user data
+- `java.sql`: Provides classes for database connectivity and operations
+
+## Data Manipulation (SQL)
+
+`users`: SELECT operation to fetch user data based on username
+
+| Column Name | Data Type | Description |
+|-------------|-----------|-------------|
+| user_id     | String    | Unique identifier for the user |
+| username    | String    | User's username |
+| password    | String    | User's hashed password |
+
+## Vulnerabilities
+
+1. SQL Injection: The `fetch` method constructs an SQL query by directly concatenating user input (`un`) into the query string. This is a severe security vulnerability that could allow malicious users to manipulate the query and potentially access or modify unauthorized data.
+
+2. Weak Secret Key Handling: The `token` and `assertAuth` methods convert a string secret directly to bytes for use as an HMAC-SHA key. This approach may not provide sufficient entropy and could lead to weak keys if the secret string is not properly generated and managed.
+
+3. Exception Handling: The `assertAuth` method prints the full stack trace of exceptions, which could potentially expose sensitive information in production environments.
+
+4. Insecure Password Storage: While the class stores a `hashedPassword`, there's no evidence of proper password hashing being implemented. Storing passwords without proper hashing is a security risk.
+
+5. Lack of Prepared Statements: The database query in the `fetch` method doesn't use prepared statements, which is the recommended approach to prevent SQL injection and improve performance.
+
+6. No Connection Pooling: The database connection is opened and closed for each query, which can be inefficient for high-traffic applications.
+
+7. Potential Resource Leak: In the `fetch` method, the `Statement` object is not explicitly closed, which could lead to resource leaks.
+
+8. Insecure JWT Configuration: The JWT creation doesn't include important claims like expiration time (`exp`), issued at time (`iat`), or a unique identifier (`jti`), which are recommended for secure JWT usage.
+
+These vulnerabilities should be addressed to improve the security and reliability of the application.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 39e9bb02f9eb0bf87a91505f0ce0a26fba17b074

**Description:** This pull request modifies the `User.java` file, specifically altering the SQL query execution in the `fetch` method. The change appears to be unintentional and introduces a syntax error in the code.

**Summary:** 
- src/main/java/com/scalesec/vulnado/User.java (altered) - The line executing the SQL query has been modified, adding the characters "we" at the end of the `executeQuery` method call.

**Recommendation:** This change should be rejected as it introduces a syntax error that will break the application's functionality. The original line should be kept as is:

```java
ResultSet rs = stmt.executeQuery(query);
```

The reviewer should ask the developer to remove the added "we" at the end of this line.

**Explanation of vulnerabilities:** While this change doesn't introduce new vulnerabilities, it's important to note that the existing code is vulnerable to SQL injection attacks. The query is constructed by directly concatenating user input (`un`) into the SQL string. This is a severe security risk and should be addressed. 

To fix this vulnerability, the code should use prepared statements instead of string concatenation. Here's a suggested correction:

```java
String query = "select * from users where username = ? limit 1";
PreparedStatement pstmt = conn.prepareStatement(query);
pstmt.setString(1, un);
ResultSet rs = pstmt.executeQuery();
```

This change would prevent SQL injection attacks by properly parameterizing the query. The reviewer should strongly recommend implementing this security improvement along with rejecting the current syntactically incorrect change.