### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -3,12 +3,11 @@ package com.scalesec.vulnado;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
 
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = {RequestMethod.GET, RequestMethod.POST})
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 2ca3f821555968d88635cce21593ef44913489cb

**Description:**  
This pull request updates the `CowController.java` file by modifying the `@RequestMapping` annotation for the `/cowsay` endpoint to explicitly allow both GET and POST HTTP methods. Additionally, it removes an unused import statement for `java.io.Serializable`.

**Summary:**  
- **src/main/java/com/scalesec/vulnado/CowController.java (altered):**
  - The `@RequestMapping` annotation for the `/cowsay` endpoint was changed from:
    ```java
    @RequestMapping(value = "/cowsay")
    ```
    to:
    ```java
    @RequestMapping(value = "/cowsay", method = {RequestMethod.GET, RequestMethod.POST})
    ```
    This change makes the endpoint accessible via both GET and POST requests, instead of the default (which is all HTTP methods if not specified).
  - The import statement for `java.io.Serializable` was removed, as it was not being used anywhere in the file.

**Recommendation:**  
- Ensure that allowing both GET and POST methods for the `/cowsay` endpoint is intentional and aligns with the application's requirements. If the endpoint should only support one method (typically GET for idempotent operations or POST for operations that change state), restrict it accordingly to follow RESTful best practices.
- Review the rest of the codebase to ensure that no other unused imports remain, as they can clutter the code and reduce readability.
- Consider adding unit tests to verify that both GET and POST requests to `/cowsay` behave as expected.

**Explanation of vulnerabilities:**  
- **Potential Security Issue:** By allowing both GET and POST methods, the endpoint is now more permissive. If the endpoint is not intended to handle POST requests, this could open up unnecessary attack vectors (e.g., CSRF attacks if POST is not protected).
- **Suggested Correction:** If only GET should be allowed, restrict the method as follows:
    ```java
    @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
    ```
  If POST is required, ensure that CSRF protection is enabled in your Spring Security configuration, especially if the endpoint performs any sensitive operations (even though in this case, it appears to just echo input).

No critical vulnerabilities were introduced by this change, but the increased method exposure should be reviewed for necessity and security implications.