### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/Cowsay.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,13 +1,15 @@
 package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
+import java.util.logging.Logger;
 import java.io.InputStreamReader;
 
+  private static final Logger LOGGER = Logger.getLogger(Cowsay.class.getName());
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
     String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
+    LOGGER.info(cmd);
     processBuilder.command("bash", "-c", cmd);
 
     StringBuilder output = new StringBuilder();
@@ -21,7 +23,7 @@ public class Cowsay {
         output.append(line + "\n");
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOGGER.severe(e.getMessage());
     }
     return output.toString();
   }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 96695c254523fbee9a6df10ac1c74192379f5abb

**Description:**  
This pull request updates the `Cowsay.java` file to replace direct `System.out.println` and `e.printStackTrace()` calls with Java's `Logger` for improved logging practices. The logger is now used to log both the command being executed and any exceptions that occur.

**Summary:**  
- **src/main/java/com/scalesec/vulnado/Cowsay.java (altered):**
  - Added import for `java.util.logging.Logger`.
  - Declared a static `Logger` instance for the class.
  - Replaced `System.out.println(cmd);` with `LOGGER.info(cmd);` to log the command.
  - Replaced `e.printStackTrace();` with `LOGGER.severe(e.getMessage());` to log exceptions at the SEVERE level.

**Recommendation:**  
- The use of `Logger` is a good practice for production code, as it allows for better control over logging output and levels.
- However, the code still constructs a shell command by directly concatenating user input (`input`) into the command string. This is a **critical security vulnerability** (command injection).
- It is highly recommended to sanitize or validate the `input` before using it in a shell command, or better yet, avoid shell invocation altogether if possible.
- If shell invocation is necessary, use `ProcessBuilder` with argument lists instead of a single string, to avoid shell interpretation of user input.

**Explanation of vulnerabilities:**  
- **Command Injection Vulnerability:**  
  The following line is vulnerable:
  ```java
  String cmd = "/usr/games/cowsay '" + input + "'";
  processBuilder.command("bash", "-c", cmd);
  ```
  If `input` contains characters like `'`, `;`, or backticks, an attacker could execute arbitrary commands on the server.

  **Suggested Correction:**
  Instead of passing the entire command as a string to the shell, pass arguments directly to `ProcessBuilder`:
  ```java
  processBuilder.command("/usr/games/cowsay", input);
  ```
  This way, `input` is treated as a single argument to the `cowsay` program, not as part of a shell command, preventing command injection.

  **Example Correction:**
  ```java
  public static String run(String input) {
      ProcessBuilder processBuilder = new ProcessBuilder();
      LOGGER.info("/usr/games/cowsay " + input);
      processBuilder.command("/usr/games/cowsay", input);

      StringBuilder output = new StringBuilder();
      try {
          Process process = processBuilder.start();
          BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
          String line;
          while ((line = reader.readLine()) != null) {
              output.append(line).append("\n");
          }
      } catch (Exception e) {
          LOGGER.severe(e.getMessage());
      }
      return output.toString();
  }
  ```
- **Logging Sensitive Data:**  
  Be cautious about logging user input, as it may contain sensitive information. Consider sanitizing or redacting logs if necessary.

**In summary:**  
- The logging improvements are positive.
- The command injection vulnerability is severe and must be addressed before merging.