### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,11 +1,8 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the 3b2bbea948032e91768b8b353958601cf6b05dac

**Description:**  
This pull request cleans up the import statements in the `LinksController.java` file by removing several unused imports. The code now only imports the necessary classes for the controller to function, improving readability and maintainability.

**Summary:**  
- File altered: `src/main/java/com/scalesec/vulnado/LinksController.java`
  - Removed unused imports:
    - `org.springframework.boot.*`
    - `org.springframework.http.HttpStatus`
    - `java.io.Serializable`
  - Kept only the necessary imports for Spring Web annotations, auto-configuration, `List`, and `IOException`.

**Recommendation:**  
- The changes are positive and follow good coding practices by removing unused imports, which helps prevent confusion and reduces potential for accidental misuse of unnecessary classes.
- As a further recommendation, consider using an IDE or static analysis tool to automatically manage imports in the future, ensuring that only required dependencies are included.
- Double-check that none of the removed imports are required elsewhere in the file, especially if there are dynamic code paths or reflection-based usages (though this is rare and not recommended).

**Explanation of vulnerabilities:**  
- No security vulnerabilities were introduced or fixed in this change. Removing unused imports does not affect the security posture of the application.
- No further action is required regarding vulnerabilities for this specific change.