### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -7,12 +7,13 @@ import org.jsoup.select.Elements;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
+import java.util.logging.Logger;
 import java.net.*;
 
 
 public class LinkLister {
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +26,8 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      Logger logger = Logger.getLogger(LinkLister.class.getName());
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the af420715aa720dbb40fc43d95591ca9c9c756f33

**Description:**  
This pull request updates the `LinkLister.java` file to improve code style and logging practices. The main changes include replacing `System.out.println` with Java's built-in `Logger` for better logging, using the diamond operator for type inference in generics, and importing the `Logger` class. These changes enhance maintainability and align with Java best practices.

**Summary:**  
- **src/main/java/com/scalesec/vulnado/LinkLister.java (altered)**
  - Added import for `java.util.logging.Logger`.
  - Changed `new ArrayList<String>()` to `new ArrayList<>()` for type inference.
  - Replaced `System.out.println(host);` with a logger:  
    ```java
    Logger logger = Logger.getLogger(LinkLister.class.getName());
    logger.info(host);
    ```
  - No changes to the core logic or method signatures.

**Recommendation:**  
- The use of `Logger` is a good practice over `System.out.println`, as it allows for better control over logging levels and output destinations.
- Consider initializing the `Logger` as a static final field at the class level instead of inside the method. This avoids creating a new logger instance on every method call and is the standard Java convention:
  ```java
  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
  ```
  Then, use `logger.info(host);` directly in the method.
- If the application is multi-threaded or will be used in a production environment, consider configuring the logger to use a proper logging framework (like SLF4J with Logback or Log4j) for more flexibility and performance.
- Ensure that logging sensitive information (such as hostnames) is compliant with your organization's security and privacy policies.

**Explanation of vulnerabilities:**  
- **Potential Information Disclosure:** Logging the host of a user-supplied URL may inadvertently expose sensitive or internal information in logs, especially if the logs are accessible to unauthorized users. If the application is public-facing, consider sanitizing or limiting what is logged.
- **No Input Validation Added:** The code still only checks for private IP ranges by string prefix. This is a basic check and can be bypassed with crafted hostnames or IPv6 addresses. Consider using a more robust method to validate that the host is not internal, such as resolving the IP and checking against all private and reserved ranges.
  - **Example improvement:**
    ```java
    InetAddress address = InetAddress.getByName(host);
    if (address.isSiteLocalAddress() || address.isLoopbackAddress() || address.isAnyLocalAddress()) {
        throw new BadRequest("Use of Private IP");
    }
    ```
- **No other vulnerabilities introduced by this change.** The update is primarily a refactor for better logging and code style.

**Summary of suggestions:**
- Move logger initialization to a static final field.
- Review logging of potentially sensitive data.
- Consider more robust host/IP validation for security.