### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,11 +1,8 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the fd7976dee2796370467f82f0229710063c5d1149

**Description:**  
This pull request updates the import statements in the `LinksController.java` file by removing several unused imports. The changes are focused on cleaning up the code to improve readability and maintainability, without altering any business logic or functionality.

**Summary:**  
- **src/main/java/com/scalesec/vulnado/LinksController.java (altered):**
  - Removed the following unused imports:
    - `org.springframework.boot.*`
    - `org.springframework.http.HttpStatus`
    - `java.io.Serializable`
  - The remaining imports are those that are actually used in the file, such as `org.springframework.web.bind.annotation.*`, `org.springframework.boot.autoconfigure.*`, `java.util.List`, and `java.io.IOException`.

**Recommendation:**  
- This is a good practice for code cleanliness and maintainability. Removing unused imports helps prevent confusion and reduces the risk of accidental dependencies or future merge conflicts.
- It is recommended to always check for unused imports before committing code, as some IDEs can automatically highlight or remove them.
- No further changes are necessary for this specific update.

**Explanation of vulnerabilities:**  
- No security vulnerabilities were introduced or fixed in this change. The update is limited to import statements and does not affect the logic or data flow of the application.
- No sensitive classes or methods were exposed or altered.
- No further action is required regarding security for this change.