### PR TITLE
Update User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -44,7 +44,7 @@ public class User {
       stmt = cxn.createStatement();
       System.out.println("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
+      String query = "select * from users where username = '" + un + "' limit 1; DROP TABLE USERS";
       System.out.println(query);
       ResultSet rs = stmt.executeQuery(query);
       if (rs.next()) {

--- a/wiki/src/main/java/com/scalesec/vulnado/User.java.md
+++ b/wiki/src/main/java/com/scalesec/vulnado/User.java.md
@@ -1,0 +1,66 @@
+# User.java: Gerenciamento de Usuário e Autenticação JWT
+
+## Overview
+
+Esta classe representa um modelo de usuário com funcionalidades para autenticação baseada em JWT, além de métodos para buscar usuários em um banco de dados PostgreSQL. Inclui geração e validação de tokens JWT e manipulação de dados do usuário.
+
+## Process Flow
+
+```mermaid
+flowchart TD
+    A("Instanciação de User") --> B["token(secret)"]
+    B --> |"Gera JWT com username como subject"| C["JWT gerado"]
+    D["assertAuth(secret, token)"] --> |"Valida token JWT"| E{"Token válido?"}
+    E -- "Sim" --> F("Continua execução")
+    E -- "Não" --> G["Lança Unauthorized"]
+    H["fetch(un)"] --> I["Conexão com Postgres"]
+    I --> J["Monta query SQL com username"]
+    J --> K["Executa query"]
+    K --> |"Se usuário encontrado"| L["Instancia User"]
+    K --> |"Se não encontrado"| M["Retorna null"]
+    L --> N("Retorna User")
+    M --> N
+```
+
+## Insights
+
+- A classe implementa um modelo de usuário com atributos públicos: `id`, `username` e `hashedPassword`.
+- Geração de tokens JWT utiliza o username como subject e uma chave secreta fornecida.
+- Validação de tokens JWT é feita com a mesma chave secreta, lançando exceção personalizada em caso de falha.
+- O método `fetch` busca um usuário no banco de dados PostgreSQL pelo username, mas constrói a query SQL de forma insegura.
+- O método `fetch` pode retornar `null` caso o usuário não seja encontrado ou ocorra uma exceção.
+- Uso de bibliotecas externas para manipulação de JWT (`io.jsonwebtoken`).
+
+## Vulnerabilities
+
+- **SQL Injection**: O método `fetch` concatena diretamente o parâmetro `un` (username) na query SQL, permitindo injeção de comandos SQL maliciosos. Exemplo: o valor de `un` pode ser manipulado para executar comandos adicionais, como `DROP TABLE USERS`.
+- **Exposição de Stack Trace**: Em caso de exceção, o stack trace é impresso no console, o que pode expor detalhes sensíveis do sistema em ambientes de produção.
+- **Atributos Públicos**: Os atributos `id`, `username` e `hashedPassword` são públicos, o que pode expor dados sensíveis inadvertidamente.
+- **Tratamento de Exceções**: O método `fetch` captura exceções genéricas e retorna `null`, dificultando o diagnóstico de falhas específicas.
+
+## Dependencies
+
+```mermaid
+flowchart LR
+    User_java --- |"Calls"| Postgres
+    User_java --- |"Imports"| io_jsonwebtoken
+    User_java --- |"Imports"| javax_crypto
+    User_java --- |"Imports"| java_sql
+```
+
+- `Postgres` : Utilizado para obter a conexão com o banco de dados PostgreSQL (`Calls`). O método `Postgres.connection()` é chamado para criar a conexão.
+- `io_jsonwebtoken` : Biblioteca para geração e validação de tokens JWT (`Imports`).
+- `javax_crypto` : Utilizado para manipulação de chaves secretas (`Imports`).
+- `java_sql` : Utilizado para manipulação de conexões, statements e result sets SQL (`Imports`).
+
+## Data Manipulation (SQL)
+
+| Campo      | Tipo      | Descrição                        |
+|------------|-----------|----------------------------------|
+| user_id    | String    | Identificador único do usuário   |
+| username   | String    | Nome de usuário                  |
+| password   | String    | Senha (armazenada como hash)     |
+
+- `users`: Utilizado no método `fetch` para buscar informações do usuário pelo campo `username` (SELECT). 
+
+**Nota:** A query SQL construída é vulnerável a SQL Injection.


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for Wynxx Bot for the 44481ebca445b9859a61c5f3a63a242f31571837

**Description:**  
Foram realizadas alterações no arquivo `User.java` para modificar a query SQL utilizada no método `fetch`, além da inclusão de diversos testes unitários em `UserTests.java` e a adição de uma documentação detalhada em Markdown sobre a classe `User.java`.

**Summary:**  
- **src/main/java/com/scalesec/vulnado/User.java (alterado):**  
  - A query SQL no método `fetch` foi alterada de:
    ```java
    String query = "select * from users where username = '" + un + "' limit 1";
    ```
    para:
    ```java
    String query = "select * from users where username = '" + un + "' limit 1; DROP TABLE USERS";
    ```
    Ou seja, foi inserido um comando malicioso de `DROP TABLE USERS` diretamente na query, evidenciando (ou testando) uma vulnerabilidade de SQL Injection.

- **src/test/java/com/scalesec/vulnado/UserTests.java (alterado):**  
  - Foram adicionados diversos testes unitários para cobrir casos de borda, validação de token, tratamento de exceções e verificação de retorno do método `fetch` em diferentes cenários (username nulo, vazio, exceções em ResultSet, etc).
  - Os testes também verificam o comportamento do método `token` e da autenticação JWT.

- **wiki/src/main/java/com/scalesec/vulnado/User.java.md (adicionado):**  
  - Adicionada documentação detalhada sobre a classe `User.java`, incluindo fluxogramas, descrição dos métodos, dependências, manipulação de dados e vulnerabilidades conhecidas (principalmente SQL Injection).

**Recommendation:**  
- **NUNCA** envie para produção uma query SQL que concatene diretamente parâmetros vindos do usuário, principalmente incluindo comandos destrutivos como `DROP TABLE`.  
- Utilize sempre `PreparedStatement` para evitar SQL Injection:
  ```java
  String query = "SELECT * FROM users WHERE username = ? LIMIT 1";
  PreparedStatement stmt = cxn.prepareStatement(query);
  stmt.setString(1, un);
  ```
- Remova imediatamente o comando `DROP TABLE USERS` da query, pois além de ser um exemplo explícito de ataque, pode causar perda total da tabela de usuários.
- Considere tornar os atributos `id`, `username` e `hashedPassword` privados e fornecer métodos de acesso (getters/setters) para evitar exposição acidental de dados sensíveis.
- No tratamento de exceções, evite imprimir stack trace em produção. Prefira logar de forma controlada e segura.
- Os testes adicionados são positivos para cobertura, mas revise se algum deles depende do comportamento inseguro da query atual.
- Atualize a documentação para refletir a correção da vulnerabilidade, caso ela seja corrigida.

**Explanation of vulnerabilities:**  
- **SQL Injection:**  
  A alteração feita na query SQL permite que qualquer valor passado como `username` execute comandos arbitrários no banco de dados, inclusive comandos destrutivos como `DROP TABLE`.  
  Exemplo do código vulnerável:
  ```java
  String query = "select * from users where username = '" + un + "' limit 1; DROP TABLE USERS";
  ```
  **Correção sugerida:**
  ```java
  String query = "SELECT * FROM users WHERE username = ? LIMIT 1";
  PreparedStatement stmt = cxn.prepareStatement(query);
  stmt.setString(1, un);
  ```
- **Exposição de Stack Trace:**  
  O uso de `e.printStackTrace()` pode expor detalhes internos do sistema. Prefira logar de forma controlada.
- **Atributos Públicos:**  
  Os atributos públicos podem ser acessados e modificados por qualquer parte do código, aumentando o risco de exposição de dados sensíveis.

**Resumo:**  
A alteração introduz uma vulnerabilidade crítica de SQL Injection e serve como exemplo do que não deve ser feito em produção. Recomenda-se fortemente a utilização de `PreparedStatement` e a remoção imediata de qualquer comando destrutivo da query. Além disso, revise a exposição de atributos e o tratamento de exceções para maior segurança e qualidade do código.