### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/CowController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -3,12 +3,11 @@ package com.scalesec.vulnado;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 
-import java.io.Serializable;
 
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado pelo Wynxx Bot para o commit 9745cd01cb40fe108e4c9bf3bf3820118a7bfe5b

**Descrição:** Atualização no arquivo CowController.java para especificar explicitamente o método HTTP GET para o endpoint /cowsay e remoção de uma importação não utilizada.

**Resumo:** 
- `src/main/java/com/scalesec/vulnado/CowController.java` (alterado) - Duas alterações foram realizadas:
  1. Especificação explícita do método HTTP GET para o endpoint `/cowsay` através da adição do parâmetro `method = RequestMethod.GET` na anotação `@RequestMapping`
  2. Remoção da importação não utilizada `java.io.Serializable`

**Recomendação:** 
A alteração é positiva pois melhora a segurança da aplicação ao restringir explicitamente o endpoint para aceitar apenas requisições GET. Recomendo aprovar esta alteração, pois segue boas práticas de desenvolvimento ao:
1. Remover importações não utilizadas, melhorando a legibilidade do código
2. Especificar explicitamente o método HTTP permitido, o que é uma boa prática de segurança

Sugiro também considerar a migração da anotação `@RequestMapping` para a mais específica `@GetMapping`, que é mais moderna e deixa o código ainda mais claro.

**Explicação de vulnerabilidades:** 
A alteração corrige uma potencial vulnerabilidade de segurança. Quando não especificamos o método HTTP em um endpoint, ele aceita qualquer tipo de requisição (GET, POST, PUT, DELETE, etc.). Isso pode permitir que atacantes enviem dados maliciosos através de métodos não esperados, como POST.

Ao restringir explicitamente para GET, o endpoint só aceitará esse tipo de requisição, reduzindo a superfície de ataque. Uma melhoria adicional seria:

```java
// Em vez de:
@RequestMapping(value = "/cowsay", method = RequestMethod.GET)

// Usar a anotação mais específica:
@GetMapping("/cowsay")
```

Esta abordagem é mais moderna e mantém o mesmo comportamento de segurança.