### PR TITLE
[GFTCodeFixer]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -4,6 +4,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import java.util.logging.Logger;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
@@ -11,9 +12,13 @@ import java.net.*;
 
 
 public class LinkLister {
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+
+    List<String> result = new ArrayList<>();
+  private LinkLister() {}
     Document doc = Jsoup.connect(url).get();
+
     Elements links = doc.select("a");
     for (Element link : links) {
       result.add(link.absUrl("href"));
@@ -25,7 +30,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado pelo Wynxx Bot para o 9490c2f3cc72a2ccea2460bf0f613ef5133cfd8c

**Descrição:** Atualização do arquivo LinkLister.java para melhorar a segurança e seguir boas práticas de programação, incluindo a adição de um logger adequado, construtor privado para classe utilitária e otimização de declarações de lista.

**Resumo:** 
- **src/main/java/com/scalesec/vulnado/LinkLister.java (alterado)** - Foram realizadas várias melhorias:
  1. Adicionado import para java.util.logging.Logger
  2. Implementado um logger adequado para substituir System.out.println
  3. Adicionado construtor privado para evitar instanciação da classe utilitária
  4. Otimizada a declaração de ArrayList usando diamond operator
  5. Melhorada a formatação do código com espaçamentos adequados

**Recomendação:** 
1. Considerar o uso de um framework de logging mais robusto como SLF4J ou Log4j2 em vez do Logger padrão do Java, pois oferecem mais recursos e flexibilidade.
2. Verificar se a classe LinkLister realmente deve ser uma classe utilitária estática ou se deveria ser instanciável com estado.
3. Avaliar se o método getLinksV2 está completo, pois o código mostrado parece estar incompleto (não mostra o retorno do método).
4. Considerar adicionar validação de URL no início do método getLinks para evitar processamento desnecessário de URLs inválidas.

**Explicação de vulnerabilidades:** 
1. **Correção de vazamento de informações**: A substituição de `System.out.println(host)` por `LOGGER.info(host)` é uma melhoria de segurança, pois evita que informações potencialmente sensíveis sejam impressas diretamente no console, onde poderiam ser facilmente acessadas. O uso de um logger permite controlar melhor o nível de log e o destino das mensagens.

2. **Prevenção de instanciação desnecessária**: A adição do construtor privado `private LinkLister() {}` impede a criação de instâncias desnecessárias desta classe utilitária, seguindo o padrão de design para classes que contêm apenas métodos estáticos.

3. **Ainda existe uma possível vulnerabilidade de SSRF (Server-Side Request Forgery)** no método getLinks, pois ele aceita qualquer URL sem validação prévia. Embora o método getLinksV2 pareça implementar alguma proteção contra IPs privados, o método getLinks original continua vulnerável. Recomendo adicionar validação similar no método getLinks:

```java
public static List<String> getLinks(String url) throws IOException, BadRequest {
    // Validar URL antes de fazer a conexão
    URL aUrl = new URL(url);
    String host = aUrl.getHost();
    if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")) {
        throw new BadRequest("Use of Private IP");
    }
    
    List<String> result = new ArrayList<>();
    Document doc = Jsoup.connect(url).get();
    // resto do código...
}
```