### PR TITLE
Update LoginController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LoginController.java
+++ b/src/main/java/com/scalesec/vulnado/LoginController.java
@@ -15,8 +15,7 @@ public class LoginController {
   private String secret;
 
   @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/login", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
-  LoginResponse login(@RequestBody LoginRequest input) {
+  @RequestMapping(value = "/login", method = RequestMethod.P
     User user = User.fetch(input.username);
     if (Postgres.md5(input.password).equals(user.hashedPassword)) {
       return new LoginResponse(user.token(secret));


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for Wynxx Bot for the b0445ddd2897132c8a14d9af69b54a5d4aba5fc0

**Description:** This pull request modifies the LoginController.java file by truncating the RequestMapping annotation for the login endpoint. The change appears to be incomplete or erroneous as it cuts off the HTTP method definition and removes the method signature.

**Summary:** 
- **src/main/java/com/scalesec/vulnado/LoginController.java (altered)** - The RequestMapping annotation for the login endpoint has been modified from `@RequestMapping(value = "/login", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")` to an incomplete `@RequestMapping(value = "/login", method = RequestMethod.P`. Additionally, the method signature `LoginResponse login(@RequestBody LoginRequest input) {` has been removed.

**Recommendation:** This pull request should be rejected as it introduces a critical error in the code. The RequestMapping annotation is incomplete, cutting off at `RequestMethod.P` instead of `RequestMethod.POST`, and the method signature is completely removed. This would cause compilation errors and break the login functionality. The original code should be maintained or properly updated with a complete implementation.

**Explanation of vulnerabilities:** While the original code might have security concerns related to cross-origin requests with `@CrossOrigin(origins = "*")` which allows requests from any domain (potentially enabling CSRF attacks), this pull request doesn't address that issue but instead introduces a critical error. The proper fix would be to either:

1. Specify allowed origins instead of using the wildcard:
```java
@CrossOrigin(origins = "https://trusted-domain.com")
@RequestMapping(value = "/login", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
LoginResponse login(@RequestBody LoginRequest input) {
```

2. Or implement proper CSRF protection if cross-origin requests are necessary.